### PR TITLE
Fix error when RunHistory.xml file is not present (first run)

### DIFF
--- a/Office365APIEditor/UI/RequestForm.cs
+++ b/Office365APIEditor/UI/RequestForm.cs
@@ -1224,7 +1224,9 @@ namespace Office365APIEditor
             };
 
             // Add new history.
-            if (runHistory.RunInfo.Last().ResponseBody == newRunInfo.ResponseBody)
+            if (Convert.ToBoolean(runHistory.RunInfo.Count) &&
+                    runHistory.RunInfo.Last().RequestUrl == newRunInfo.RequestUrl &&
+                    runHistory.RunInfo.Last().ResponseBody == newRunInfo.ResponseBody)
                 runHistory.RunInfo.RemoveAt(runHistory.RunInfo.Count - 1);
             runHistory.RunInfo.Add(newRunInfo);
 


### PR DESCRIPTION
Fix exception when RunHistory.xml file is not present (first run)

```
System.InvalidOperationException
  HResult=0x80131509
  Message=Sequence contains no elements
  Source=System.Core
  StackTrace:
   at System.Linq.Enumerable.Last[TSource](IEnumerable`1 source)
   at Office365APIEditor.RequestForm.AddRunHistory(WebRequest Request, String RequestHeader, String RequestBody, HttpWebResponse Response, String JsonResponse) in Office365APIEditor\Office365APIEditor\UI\RequestForm.cs:line 1227
   at Office365APIEditor.RequestForm.<RunRequestAsync>d__18.MoveNext() in Office365APIEditor\Office365APIEditor\UI\RequestForm.cs:line 739
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Office365APIEditor.RequestForm.<button_Run_Click>d__17.MoveNext() in Office365APIEditor\Office365APIEditor\UI\RequestForm.cs:line 351
```